### PR TITLE
Align API structure with Twelve Data docs and add press releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're upgrading from `v0.1.x`, see `MIGRATION.md`.
 
 # Covered:
 
-## Core Data
+## Market data
 
 * Time series          ✅ **High demand**
 * Time series cross    ✅
@@ -25,28 +25,28 @@ If you're upgrading from `v0.1.x`, see `MIGRATION.md`.
 ## Reference Data
 
 ### Asset Catalogs
-* Stocks list           ✅
-* Forex Pairs List      ✅
-* Cryptocurrencies List ✅
+* Stocks                ✅
+* Forex pairs           ✅
+* Cryptocurrency pairs  ✅
 * ETFs                  ✅
 * Funds                 ✅
 * Commodities           ✅
-* Fixed Income          ✅
+* Fixed income          ✅
 
 ### Discovery
 * Symbol search         ✅ **High demand**
-* Cross Listings        ✅
+* Cross listings        ✅
 * Earliest timestamp    ✅
 
 ### Markets
 * Exchanges                ✅ **High demand**
-* Exchanges Schedule       ✅
+* Exchanges schedule       ✅
 * Cryptocurrency exchanges ✅
 * Market state             ✅
 
 ### Supporting Metadata
 * Countries             ✅
-* Instrument Type       ✅
+* Instrument type       ✅
 * Technical indicators  ✅
 
 ## Fundamentals
@@ -54,57 +54,53 @@ If you're upgrading from `v0.1.x`, see `MIGRATION.md`.
 * Logo                  ✅
 * Profile               ✅ **Useful**
 * Dividends             ✅
-* Dividends Calendar    ✅
+* Dividends calendar    ✅
 * Splits                ✅
-* Splits Calendar       ✅
+* Splits calendar       ✅
 * Earnings              ✅
 * Earnings calendar     ✅
 * IPO calendar          ✅
 * Statistics            ✅
+* Press releases        ✅ **New**
 * Income statement      ✅
 * Income statement consolidated ✅ **New**
 * Balance sheet         ✅
 * Balance sheet consolidated ✅ **New**
 * Cash flow             ✅
 * Cash flow consolidated ✅ **New**
-* Insider transactions  ✅
 * Key executives        ✅ **Useful**
-* Market Capitalization ✅ **New**
-* Last Changes          ✅ **New**
+* Market capitalization ✅ **New**
+* Last changes          ✅ **New**
 
 ## Currencies
 
 * Exchange rate         ✅
 * Currency conversion   ✅ **Useful**
 
-## WebSocket
-
-* Real-time price ✅ **Useful**
-
 ## ETFs
 
-* ETFs Directory        ✅ **Useful**
-* ETF Full Data         ✅ **High demand**
-* ETF Summary           ✅
-* ETF Performance       ✅ **High demand**
-* ETF Risk              ✅
-* ETF Composition       ✅ **High demand**
-* ETF Families          ✅
-* ETF Types             ✅
+* ETFs directory        ✅ **Useful**
+* ETF full data         ✅ **High demand**
+* Summary               ✅
+* Performance           ✅ **High demand**
+* Risk                  ✅
+* Composition           ✅ **High demand**
+* ETFs families         ✅
+* ETFs types            ✅
 
 ## Mutual Funds
 
-* Mutual Funds Directory         ✅ **Useful**
-* Mutual Fund Full Data          ✅ **High demand**
-* Mutual Fund Summary            ✅
-* Mutual Fund Performance        ✅ **High demand**
-* Mutual Fund Risk               ✅
-* Mutual Fund Ratings            ✅
-* Mutual Fund Composition        ✅ **High demand**
-* Mutual Fund Purchase Info      ✅
-* Mutual Fund Sustainability     ✅
-* Mutual Fund Families           ✅
-* Mutual Fund Types              ✅
+* MFs directory                  ✅ **Useful**
+* MF full data                   ✅ **High demand**
+* Summary                        ✅
+* Performance                    ✅ **High demand**
+* Risk                           ✅
+* Ratings                        ✅
+* Composition                    ✅ **High demand**
+* Purchase info                  ✅
+* Sustainability                 ✅
+* MFs families                   ✅
+* MFs types                      ✅
 
 ## Technical Indicators
 
@@ -250,6 +246,10 @@ If you're upgrading from `v0.1.x`, see `MIGRATION.md`.
 
 * Batches      ✅ **Useful**
 * API usage    ✅
+
+## WebSocket
+
+* Real-time price ✅ **Useful**
 
 
 # Usage

--- a/client.go
+++ b/client.go
@@ -1,5 +1,5 @@
 // Package twelvedata provides a Go client for the Twelve Data API, offering comprehensive access to
-// financial market data including real-time quotes, historical time series, fundamental data, and more.
+// market data, reference data, fundamentals, and more.
 package twelvedata
 
 import (
@@ -9,8 +9,16 @@ import (
 
 // Client defines the interface for interacting with the Twelve Data API.
 // It provides methods for accessing various financial data endpoints including
-// reference data, core market data, fundamentals, currencies, and WebSocket streaming.
+// market data, reference data, fundamentals, and currencies.
 type Client interface {
+	// Market Data
+	GetTimeSeries(request.GetTimeSeries) (response.TimeSeries, response.Credits, error)
+	GetTimeSeriesCross(request.GetTimeSeriesCross) (response.TimeSeriesCross, response.Credits, error)
+	GetQuote(request.GetQuote) (response.Quote, response.Credits, error)
+	GetPrice(request.GetPrice) (response.Price, response.Credits, error)
+	GetEOD(request.GetEOD) (response.EOD, response.Credits, error)
+	GetMarketMovers(request.GetMarketMovers) (response.MarketMovers, response.Credits, error)
+
 	// Reference Data - Asset Catalogs
 	GetStocks(request.GetStock) (response.Stocks, response.Credits, error)
 	GetForexPairs(request.GetForexPairs) (response.ForexPairs, response.Credits, error)
@@ -36,34 +44,54 @@ type Client interface {
 	GetInstrumentType(request.GetInstrumentType) (response.InstrumentType, response.Credits, error)
 	GetTechnicalIndicators(request.GetTechnicalIndicators) (response.TechnicalIndicators, response.Credits, error)
 
-	// Core Data
-	GetTimeSeries(request.GetTimeSeries) (response.TimeSeries, response.Credits, error)
-	GetTimeSeriesCross(request.GetTimeSeriesCross) (response.TimeSeriesCross, response.Credits, error)
-	GetQuote(request.GetQuote) (response.Quote, response.Credits, error)
-	GetPrice(request.GetPrice) (response.Price, response.Credits, error)
-	GetEOD(request.GetEOD) (response.EOD, response.Credits, error)
-	GetMarketMovers(request.GetMarketMovers) (response.MarketMovers, response.Credits, error)
-
 	// Fundamentals
 	GetLogo(request.GetLogo) (response.Logo, response.Credits, error)
 	GetProfile(request.GetProfile) (response.Profile, response.Credits, error)
-	GetKeyExecutives(request.GetKeyExecutives) (response.KeyExecutives, response.Credits, error)
 	GetDividends(request.GetDividends) (response.Dividends, response.Credits, error)
 	GetDividendsCalendar(request.GetDividendsCalendar) (response.DividendsCalendar, response.Credits, error)
 	GetEarnings(request.GetEarnings) (response.Earnings, response.Credits, error)
+	GetEarningsCalendar(request.GetEarningsCalendar) (response.EarningsCalendar, response.Credits, error)
+	GetIPOCalendar(request.GetIPOCalendar) (response.IPOCalendar, response.Credits, error)
 	GetSplits(request.GetSplits) (response.Splits, response.Credits, error)
 	GetSplitsCalendar(request.GetSplitsCalendar) (response.SplitsCalendar, response.Credits, error)
 	GetStatistics(statistics request.GetStatistics) (response.Statistics, response.Credits, error)
-	GetEarningsCalendar(request.GetEarningsCalendar) (response.EarningsCalendar, response.Credits, error)
-	GetIPOCalendar(request.GetIPOCalendar) (response.IPOCalendar, response.Credits, error)
+	GetPressReleases(request.GetPressReleases) (response.PressReleases, response.Credits, error)
 	GetIncomeStatement(request.GetIncomeStatement) (response.IncomeStatements, response.Credits, error)
 	GetIncomeStatementConsolidated(request.GetIncomeStatement) (response.IncomeStatements, response.Credits, error)
 	GetBalanceSheet(request.GetBalanceSheet) (response.BalanceSheets, response.Credits, error)
 	GetBalanceSheetConsolidated(request.GetBalanceSheet) (response.BalanceSheets, response.Credits, error)
 	GetCashFlow(request.GetCashFlow) (response.CashFlows, response.Credits, error)
 	GetCashFlowConsolidated(request.GetCashFlow) (response.CashFlows, response.Credits, error)
+	GetKeyExecutives(request.GetKeyExecutives) (response.KeyExecutives, response.Credits, error)
 	GetMarketCap(request.GetMarketCap) (response.MarketCap, response.Credits, error)
 	GetLastChange(request.GetLastChange) (response.LastChange, response.Credits, error)
+
+	// Currencies
+	GetExchangeRate(request.GetExchangeRate) (response.ExchangeRate, response.Credits, error)
+	GetCurrencyConversion(request.GetCurrencyConversion) (response.CurrencyConversion, response.Credits, error)
+
+	// ETFs
+	GetETFsDirectory(request.GetETFsDirectory) (response.ETFsDirectory, response.Credits, error)
+	GetETFFullData(request.GetETFFullData) (response.ETFFullData, response.Credits, error)
+	GetETFSummary(request.GetETFSummary) (response.ETFWorldSummary, response.Credits, error)
+	GetETFPerformance(request.GetETFPerformance) (response.ETFPerformance, response.Credits, error)
+	GetETFRisk(request.GetETFRisk) (response.ETFRisk, response.Credits, error)
+	GetETFComposition(request.GetETFComposition) (response.ETFComposition, response.Credits, error)
+	GetETFFamilies(request.GetETFFamilies) (response.ETFFamilies, response.Credits, error)
+	GetETFTypes(request.GetETFTypes) (response.ETFTypes, response.Credits, error)
+
+	// Mutual Funds
+	GetMutualFundsDirectory(request.GetMutualFundsDirectory) (response.MutualFundsDirectory, response.Credits, error)
+	GetMutualFundFullData(request.GetMutualFundFullData) (response.MutualFundFullData, response.Credits, error)
+	GetMutualFundSummary(request.GetMutualFundSummary) (response.MutualFundSummary, response.Credits, error)
+	GetMutualFundPerformance(request.GetMutualFundPerformance) (response.MutualFundPerformance, response.Credits, error)
+	GetMutualFundRisk(request.GetMutualFundRisk) (response.MutualFundRisk, response.Credits, error)
+	GetMutualFundRatings(request.GetMutualFundRatings) (response.MutualFundRatings, response.Credits, error)
+	GetMutualFundComposition(request.GetMutualFundComposition) (response.MutualFundComposition, response.Credits, error)
+	GetMutualFundPurchaseInfo(request.GetMutualFundPurchaseInfo) (response.MutualFundPurchaseInfo, response.Credits, error)
+	GetMutualFundSustainability(request.GetMutualFundSustainability) (response.MutualFundSustainability, response.Credits, error)
+	GetMutualFundFamilies(request.GetMutualFundFamilies) (response.MutualFundFamilies, response.Credits, error)
+	GetMutualFundTypes(request.GetMutualFundTypes) (response.MutualFundTypes, response.Credits, error)
 
 	// Technical Indicators
 	GetBBands(request.GetBBands) (response.BBands, response.Credits, error)
@@ -92,37 +120,6 @@ type Client interface {
 	GetNATR(request.GetNATR) (response.NATR, response.Credits, error)
 	GetTR(request.GetTR) (response.TR, response.Credits, error)
 
-	// Currencies
-	GetExchangeRate(request.GetExchangeRate) (response.ExchangeRate, response.Credits, error)
-	GetCurrencyConversion(request.GetCurrencyConversion) (response.CurrencyConversion, response.Credits, error)
-
-	// Advanced
-	GetUsage(request.GetUsage) (response.Usage, response.Credits, error)
-	GetBatches(request.GetBatches) (response.Batches, response.Credits, error)
-
-	// ETFs
-	GetETFsDirectory(request.GetETFsDirectory) (response.ETFsDirectory, response.Credits, error)
-	GetETFFullData(request.GetETFFullData) (response.ETFFullData, response.Credits, error)
-	GetETFSummary(request.GetETFSummary) (response.ETFWorldSummary, response.Credits, error)
-	GetETFPerformance(request.GetETFPerformance) (response.ETFPerformance, response.Credits, error)
-	GetETFRisk(request.GetETFRisk) (response.ETFRisk, response.Credits, error)
-	GetETFComposition(request.GetETFComposition) (response.ETFComposition, response.Credits, error)
-	GetETFFamilies(request.GetETFFamilies) (response.ETFFamilies, response.Credits, error)
-	GetETFTypes(request.GetETFTypes) (response.ETFTypes, response.Credits, error)
-
-	// Mutual Funds
-	GetMutualFundsDirectory(request.GetMutualFundsDirectory) (response.MutualFundsDirectory, response.Credits, error)
-	GetMutualFundFullData(request.GetMutualFundFullData) (response.MutualFundFullData, response.Credits, error)
-	GetMutualFundSummary(request.GetMutualFundSummary) (response.MutualFundSummary, response.Credits, error)
-	GetMutualFundPerformance(request.GetMutualFundPerformance) (response.MutualFundPerformance, response.Credits, error)
-	GetMutualFundRisk(request.GetMutualFundRisk) (response.MutualFundRisk, response.Credits, error)
-	GetMutualFundRatings(request.GetMutualFundRatings) (response.MutualFundRatings, response.Credits, error)
-	GetMutualFundComposition(request.GetMutualFundComposition) (response.MutualFundComposition, response.Credits, error)
-	GetMutualFundPurchaseInfo(request.GetMutualFundPurchaseInfo) (response.MutualFundPurchaseInfo, response.Credits, error)
-	GetMutualFundSustainability(request.GetMutualFundSustainability) (response.MutualFundSustainability, response.Credits, error)
-	GetMutualFundFamilies(request.GetMutualFundFamilies) (response.MutualFundFamilies, response.Credits, error)
-	GetMutualFundTypes(request.GetMutualFundTypes) (response.MutualFundTypes, response.Credits, error)
-
 	// Analysis
 	GetRecommendations(request.GetRecommendations) (response.Recommendations, response.Credits, error)
 	GetPriceTarget(request.GetPriceTarget) (response.PriceTarget, response.Credits, error)
@@ -142,4 +139,8 @@ type Client interface {
 	GetDirectHolders(request.GetDirectHolders) (response.DirectHolders, response.Credits, error)
 	GetTaxInformation(request.GetTaxInformation) (response.TaxInformation, response.Credits, error)
 	GetSanctionedEntities(request.GetSanctionedEntities) (response.SanctionedEntities, response.Credits, error)
+
+	// Advanced
+	GetUsage(request.GetUsage) (response.Usage, response.Credits, error)
+	GetBatches(request.GetBatches) (response.Batches, response.Credits, error)
 }

--- a/client_press_releases_test.go
+++ b/client_press_releases_test.go
@@ -1,0 +1,228 @@
+package twelvedata
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/soulgarden/twelvedata/request"
+	"github.com/soulgarden/twelvedata/response"
+	"github.com/valyala/fasthttp"
+)
+
+func Test_client_GetPressReleases(t *testing.T) {
+	type args struct {
+		req request.GetPressReleases
+		url string
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		want        response.PressReleases
+		want1       response.Credits
+		wantErr     string
+		expectedURL string
+	}{
+		{
+			name: "success with all filters",
+			args: args{
+				req: request.GetPressReleases{
+					APIKey: request.APIKey{APIKey: ""},
+					Symbol: "AAPL",
+					Figi:   "BBG000B9Y5X2",
+					Isin:   "US0378331005",
+					Cusip:  "037833100",
+
+					Exchange:   "NASDAQ",
+					MicCode:    "XNAS",
+					StartDate:  "2025-12-01T00:00:00",
+					EndDate:    "2025-12-31T23:59:00",
+					Language:   "en,en-US",
+					TimeZone:   "America/New_York",
+					OutputSize: 3,
+				},
+				url: mockServerWithURL(
+					t,
+					http.StatusOK,
+					100,
+					50,
+					`{
+					  "press_releases": [
+					    {
+					      "id": "20251201SF35699",
+					      "datetime": "2025-12-01T11:21:00+01:00",
+					      "title": "NVIDIA and Synopsys Announce Strategic Partnership",
+					      "body": "<b>Key Highlights</b><ul><li>Example</li></ul>",
+					      "style": "/* Style Definitions */",
+					      "language": ["en", "en-US"]
+					    }
+					  ],
+					  "status": "ok"
+					}`,
+					"/?cusip=037833100&end_date=2025-12-31T23%3A59%3A00&exchange=NASDAQ&figi=BBG000B9Y5X2&isin=US0378331005&language=en%2Cen-US&mic_code=XNAS&outputsize=3&start_date=2025-12-01T00%3A00%3A00&symbol=AAPL&timezone=America%2FNew_York",
+				),
+			},
+			want: response.PressReleases{
+				PressReleases: []response.PressRelease{
+					{
+						ID:       "20251201SF35699",
+						Datetime: "2025-12-01T11:21:00+01:00",
+						Title:    "NVIDIA and Synopsys Announce Strategic Partnership",
+						Body:     "<b>Key Highlights</b><ul><li>Example</li></ul>",
+						Style:    "/* Style Definitions */",
+						Language: []string{"en", "en-US"},
+					},
+				},
+				Status: "ok",
+			},
+			want1:       response.NewCreditsImpl(100, 50),
+			wantErr:     "",
+			expectedURL: "/?cusip=037833100&end_date=2025-12-31T23%3A59%3A00&exchange=NASDAQ&figi=BBG000B9Y5X2&isin=US0378331005&language=en%2Cen-US&mic_code=XNAS&outputsize=3&start_date=2025-12-01T00%3A00%3A00&symbol=AAPL&timezone=America%2FNew_York",
+		},
+		{
+			name: "success with figi only and empty list",
+			args: args{
+				req: request.GetPressReleases{
+					APIKey:     request.APIKey{APIKey: ""},
+					Figi:       "BBG000B9Y5X2",
+					OutputSize: 1,
+				},
+				url: mockServerWithURL(
+					t,
+					http.StatusOK,
+					80,
+					50,
+					`{
+					  "press_releases": [],
+					  "status": "ok"
+					}`,
+					"/?figi=BBG000B9Y5X2&outputsize=1",
+				),
+			},
+			want: response.PressReleases{
+				PressReleases: []response.PressRelease{},
+				Status:        "ok",
+			},
+			want1:       response.NewCreditsImpl(80, 50),
+			wantErr:     "",
+			expectedURL: "/?figi=BBG000B9Y5X2&outputsize=1",
+		},
+		{
+			name: "wrong api key",
+			args: args{
+				req: request.GetPressReleases{
+					APIKey: request.APIKey{APIKey: ""},
+					Symbol: "AAPL",
+				},
+				url: mockServerWithURL(
+					t,
+					http.StatusOK,
+					100,
+					0,
+					`{"code":401,"message":"**apikey** parameter is incorrect or not specified. You can get your free API key instantly following this link: https://twelvedata.com/pricing. If you believe that everything is correct, you can contact us at https://twelvedata.com/contact/customer","status":"error"}`,
+					"/?symbol=AAPL",
+				),
+			},
+			want:  response.PressReleases{},
+			want1: response.NewCreditsImpl(100, 0),
+			wantErr: "error received: code: 401, message: **apikey** parameter is incorrect or not specified. " +
+				"You can get your free API key instantly following this link: https://twelvedata.com/pricing. " +
+				"If you believe that everything is correct, you can contact us at https://twelvedata.com/contact/customer, status: error",
+			expectedURL: "/?symbol=AAPL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testEndpointCall(
+				t,
+				tt.name,
+				tt.args,
+				tt.want,
+				tt.want1,
+				tt.wantErr,
+				func(httpCli *HTTPCli, url string) interface{} {
+					return client{
+						getPressReleases: NewEndpoint[request.GetPressReleases, response.PressReleases, response.Credits, error](httpCli, url),
+					}
+				},
+				func(cli interface{}, req request.GetPressReleases) (response.PressReleases, response.Credits, error) {
+					return cli.(client).GetPressReleases(req)
+				},
+				"GetPressReleases",
+			)
+		})
+	}
+}
+
+func TestNewClient_GetPressReleases(t *testing.T) {
+	serverURL := mockServerWithURL(
+		t,
+		http.StatusOK,
+		42,
+		50,
+		`{
+		  "press_releases": [
+		    {
+		      "id": "20260311C7828",
+		      "datetime": "2026-03-11T14:45:00Z",
+		      "title": "Example title",
+		      "body": "<p>Example body</p>",
+		      "style": "/* style */",
+		      "language": ["en"]
+		    }
+		  ],
+		  "status": "ok"
+		}`,
+		"/press_releases?symbol=AAPL",
+	)
+
+	cfg := &Conf{
+		BaseURL: serverURL,
+		Timeout: 1,
+		Fundamentals: Fundamentals{
+			PressReleasesURL: "/press_releases",
+		},
+	}
+	logger := zerolog.Nop()
+	httpCli := NewHTTPCli(&fasthttp.Client{}, cfg, &logger)
+	cli := NewClient(httpCli, cfg)
+
+	got, credits, err := cli.GetPressReleases(request.GetPressReleases{
+		APIKey: request.APIKey{APIKey: ""},
+		Symbol: "AAPL",
+	})
+	if err != nil {
+		t.Fatalf("GetPressReleases() error = %v", err)
+	}
+
+	want := response.PressReleases{
+		PressReleases: []response.PressRelease{
+			{
+				ID:       "20260311C7828",
+				Datetime: "2026-03-11T14:45:00Z",
+				Title:    "Example title",
+				Body:     "<p>Example body</p>",
+				Style:    "/* style */",
+				Language: []string{"en"},
+			},
+		},
+		Status: "ok",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetPressReleases() got = %#v, want %#v", got, want)
+	}
+
+	wantCredits := response.NewCreditsImpl(42, 50)
+	if credits.GetCreditsLeft() != wantCredits.GetCreditsLeft() || credits.GetCreditsUsed() != wantCredits.GetCreditsUsed() {
+		t.Fatalf(
+			"GetPressReleases() gotCredits = left:%d used:%d, want left:%d used:%d",
+			credits.GetCreditsLeft(),
+			credits.GetCreditsUsed(),
+			wantCredits.GetCreditsLeft(),
+			wantCredits.GetCreditsUsed(),
+		)
+	}
+}

--- a/conf.go
+++ b/conf.go
@@ -6,20 +6,33 @@ type Conf struct {
 	BaseURL   string `default:"https://api.twelvedata.com" json:"base_url"`
 	BaseWSURL string `default:"ws.twelvedata.com"          json:"base_ws_url"`
 
-	ReferenceData       ReferenceData       `json:"reference_data"`
 	CoreData            CoreData            `json:"core_data"`
+	ReferenceData       ReferenceData       `json:"reference_data"`
 	Fundamentals        Fundamentals        `json:"fundamentals"`
-	TechnicalIndicators TechnicalIndicators `json:"technical_indicators"`
 	Currencies          Currencies          `json:"currencies"`
-	WebSocket           WebSocket           `json:"web_socket"`
 	ETFs                ETFs                `json:"etfs"`
 	MutualFunds         MutualFunds         `json:"mutual_funds"`
+	TechnicalIndicators TechnicalIndicators `json:"technical_indicators"`
 	Analysis            Analysis            `json:"analysis"`
 	Regulatory          Regulatory          `json:"regulatory"`
 	Advanced            Advanced            `json:"advanced"`
+	WebSocket           WebSocket           `json:"web_socket"`
 
 	APIKey  string `default:"demo" json:"api_key"`
 	Timeout int    `default:"15"   json:"timeout"`
+}
+
+// CoreData contains URL configurations for market data endpoints including
+// time series data, quotes, prices, and end-of-day data.
+// nolint: lll
+type CoreData struct {
+	TimeSeriesURL      string `default:"/time_series"       json:"time_series_url"`
+	TimeSeriesCrossURL string `default:"/time_series/cross" json:"time_series_cross_url"`
+	QuotesURL          string `default:"/quote"             json:"quotes_url"`
+	PriceURL           string `default:"/price"             json:"price_url"`
+	EODURL             string `default:"/eod"               json:"eod_url"`
+
+	MarketMoversURL string `default:"/market_movers/{market}" json:"market_movers_url"`
 }
 
 // ReferenceData contains URL configurations for reference data endpoints including
@@ -52,47 +65,30 @@ type ReferenceData struct {
 	TechnicalIndicatorsURL string `default:"/technical_indicators" json:"technical_indicators_url"`
 }
 
-// CoreData contains URL configurations for core market data endpoints including
-// time series data, quotes, prices, and end-of-day data.
-// nolint: lll
-type CoreData struct {
-	TimeSeriesURL      string `default:"/time_series"       json:"time_series_url"`
-	TimeSeriesCrossURL string `default:"/time_series/cross" json:"time_series_cross_url"`
-	QuotesURL          string `default:"/quote"             json:"quotes_url"`
-	PriceURL           string `default:"/price"             json:"price_url"`
-	EODURL             string `default:"/eod"               json:"eod_url"`
-
-	MarketMoversURL string `default:"/market_movers/{market}" json:"market_movers_url"`
-}
-
 // Fundamentals contains URL configurations for fundamental data endpoints including
-// company profiles, financial statements, dividends, splits, and other corporate data.
+// company profiles, press releases, financial statements, dividends, splits, and other corporate data.
 // nolint: lll
 type Fundamentals struct {
 	LogoURL                        string `default:"/logo"                    json:"logo_url"`
+	ProfileURL                     string `default:"/profile"                 json:"profile_url"`
+	DividendsURL                   string `default:"/dividends"               json:"dividends_url"`
+	DividendsCalendarURL           string `default:"/dividends_calendar"      json:"dividends_calendar_url"`
+	EarningsURL                    string `default:"/earnings"                json:"earnings_url"`
 	EarningsCalendarURL            string `default:"/earnings_calendar"       json:"earnings_calendar_url"`
 	IPOCalendarURL                 string `default:"/ipo_calendar"            json:"ipo_calendar_url"`
-	ProfileURL                     string `default:"/profile"                 json:"profile_url"`
-	KeyExecutivesURL               string `default:"/key_executives"          json:"key_executives_url"`
+	SplitsURL                      string `default:"/splits"                  json:"splits_url"`
+	SplitsCalendarURL              string `default:"/splits_calendar"         json:"splits_calendar_url"`
+	StatisticsURL                  string `default:"/statistics"              json:"statistics_url"`
+	PressReleasesURL               string `default:"/press_releases"          json:"press_releases_url"`
 	IncomeStatementURL             string `default:"/income_statement"        json:"income_statement_url"`
 	IncomeStatementConsolidatedURL string `default:"/income_statement/consolidated" json:"income_statement_consolidated_url"`
 	BalanceSheetURL                string `default:"/balance_sheet"           json:"balance_sheet_url"`
 	BalanceSheetConsolidatedURL    string `default:"/balance_sheet/consolidated" json:"balance_sheet_consolidated_url"`
 	CashFlowURL                    string `default:"/cash_flow"               json:"cash_flow_url"`
 	CashFlowConsolidatedURL        string `default:"/cash_flow/consolidated" json:"cash_flow_consolidated_url"`
-	DividendsURL                   string `default:"/dividends"               json:"dividends_url"`
-	DividendsCalendarURL           string `default:"/dividends_calendar"      json:"dividends_calendar_url"`
-	EarningsURL                    string `default:"/earnings"                json:"earnings_url"`
-	SplitsURL                      string `default:"/splits"                  json:"splits_url"`
-	SplitsCalendarURL              string `default:"/splits_calendar"         json:"splits_calendar_url"`
-	StatisticsURL                  string `default:"/statistics"              json:"statistics_url"`
+	KeyExecutivesURL               string `default:"/key_executives"          json:"key_executives_url"`
 	MarketCapURL                   string `default:"/market_cap"              json:"market_cap_url"`
 	LastChangeURL                  string `default:"/last_change/{endpoint}"  json:"last_change_url"`
-}
-
-// WebSocket contains URL configurations for WebSocket endpoints used for real-time data streaming.
-type WebSocket struct {
-	PriceURL string `default:"/v1/quotes/price" json:"ws_price_url"`
 }
 
 // Currencies contains URL configurations for currency-related endpoints including exchange rates and conversions.
@@ -137,12 +133,6 @@ type TechnicalIndicators struct {
 	ATRURL  string `default:"/atr" json:"atr_url"`
 	NATRURL string `default:"/natr" json:"natr_url"`
 	TRURL   string `default:"/trange" json:"trange_url"`
-}
-
-// Advanced contains URL configurations for advanced API endpoints such as usage tracking and batch operations.
-type Advanced struct {
-	UsageURL   string `default:"/api_usage" json:"usage_url"`
-	BatchesURL string `default:"/batch"     json:"batches_url"`
 }
 
 // ETFs contains URL configurations for ETF-related endpoints including directory, full data, and performance metrics.
@@ -198,4 +188,15 @@ type Regulatory struct {
 	DirectHoldersURL        string `default:"/direct_holders"        json:"direct_holders_url"`
 	TaxInformationURL       string `default:"/tax_info"            json:"tax_information_url"`
 	SanctionedEntitiesURL   string `default:"/sanctions/{source}"  json:"sanctioned_entities_url"`
+}
+
+// Advanced contains URL configurations for advanced API endpoints such as usage tracking and batch operations.
+type Advanced struct {
+	UsageURL   string `default:"/api_usage" json:"usage_url"`
+	BatchesURL string `default:"/batch"     json:"batches_url"`
+}
+
+// WebSocket contains URL configurations for WebSocket endpoints used for real-time data streaming.
+type WebSocket struct {
+	PriceURL string `default:"/v1/quotes/price" json:"ws_price_url"`
 }

--- a/dictionary/credits.go
+++ b/dictionary/credits.go
@@ -4,7 +4,7 @@ package dictionary
 
 const (
 	// TimeSeries represents the API credit cost for time series data requests.
-	// Core Data endpoints.
+	// Market Data endpoints.
 	TimeSeries = 1
 	// TimeSeriesCross represents the API credit cost for cross-currency time series requests.
 	TimeSeriesCross = 5
@@ -84,6 +84,8 @@ const (
 	IPOCalendar = 40
 	// Statistics represents the API credit cost for company statistics requests.
 	Statistics = 50
+	// PressReleases represents the API credit cost for press releases requests.
+	PressReleases = 50
 	// IncomeStatement represents the API credit cost for income statement requests.
 	IncomeStatement = 100
 	// IncomeStatementConsolidated represents the API credit cost for consolidated income statement requests.
@@ -96,8 +98,6 @@ const (
 	CashFlow = 100
 	// CashFlowConsolidated represents the API credit cost for consolidated cash flow statement requests.
 	CashFlowConsolidated = 100
-	// InsiderTransactions represents the API credit cost for insider transactions requests.
-	InsiderTransactions = 200
 	// OptionsExpiration represents the API credit cost for options expiration requests.
 	OptionsExpiration = 50
 	// OptionsChain represents the API credit cost for options chain requests.
@@ -108,20 +108,12 @@ const (
 	MarketCapitalization = 5
 	// LastChanges represents the API credit cost for last changes requests.
 	LastChanges = 50
-	// InstitutionalHolders represents the API credit cost for institutional holders requests.
-	InstitutionalHolders = 1500
-	// FundHolders represents the API credit cost for fund holders requests.
-	FundHolders = 1500
 
 	// ExchangeRate represents the API credit cost for exchange rate requests.
 	// Currencies.
 	ExchangeRate = 1
 	// CurrencyConversion represents the API credit cost for currency conversion requests.
 	CurrencyConversion = 1
-
-	// RealTimePrice represents the API credit cost for real-time price WebSocket connections.
-	// WebSocket.
-	RealTimePrice = 1
 
 	// ETFFullData represents the API credit cost for ETF full data requests.
 	// ETFs.
@@ -239,9 +231,15 @@ const (
 	// AnalystRatingsUSEquities represents the API credit cost for US equities analyst ratings requests.
 	AnalystRatingsUSEquities = 200
 
-	// EDGARFilings represents the API credit cost for EDGAR filings requests.
+	// InsiderTransactions represents the API credit cost for insider transactions requests.
 	// Regulatory.
+	InsiderTransactions = 200
+	// EDGARFilings represents the API credit cost for EDGAR filings requests.
 	EDGARFilings = 50
+	// InstitutionalHolders represents the API credit cost for institutional holders requests.
+	InstitutionalHolders = 1500
+	// FundHolders represents the API credit cost for fund holders requests.
+	FundHolders = 1500
 	// DirectHolders represents the API credit cost for direct holders requests.
 	DirectHolders = 1500
 	// TaxInformation represents the API credit cost for tax information requests.
@@ -250,5 +248,10 @@ const (
 	SanctionedEntities = 50
 
 	// Usage represents the API credit cost for usage tracking requests.
+	// Advanced.
 	Usage = 1
+
+	// RealTimePrice represents the API credit cost for real-time price WebSocket connections.
+	// WebSocket.
+	RealTimePrice = 1
 )

--- a/implementation.go
+++ b/implementation.go
@@ -6,6 +6,14 @@ import (
 )
 
 type client struct {
+	// Market Data
+	getTimeSeries      *Endpoint[request.GetTimeSeries, response.TimeSeries, response.Credits, error]
+	getTimeSeriesCross *Endpoint[request.GetTimeSeriesCross, response.TimeSeriesCross, response.Credits, error]
+	getQuote           *Endpoint[request.GetQuote, response.Quote, response.Credits, error]
+	getPrice           *Endpoint[request.GetPrice, response.Price, response.Credits, error]
+	getEOD             *Endpoint[request.GetEOD, response.EOD, response.Credits, error]
+	getMarketMovers    *Endpoint[request.GetMarketMovers, response.MarketMovers, response.Credits, error]
+
 	// Reference Data - Asset Catalogs
 	getStocks           *Endpoint[request.GetStock, response.Stocks, response.Credits, error]
 	getForexPairs       *Endpoint[request.GetForexPairs, response.ForexPairs, response.Credits, error]
@@ -31,14 +39,6 @@ type client struct {
 	getInstrumentType      *Endpoint[request.GetInstrumentType, response.InstrumentType, response.Credits, error]
 	getTechnicalIndicators *Endpoint[request.GetTechnicalIndicators, response.TechnicalIndicators, response.Credits, error]
 
-	// Core Data
-	getTimeSeries      *Endpoint[request.GetTimeSeries, response.TimeSeries, response.Credits, error]
-	getTimeSeriesCross *Endpoint[request.GetTimeSeriesCross, response.TimeSeriesCross, response.Credits, error]
-	getQuote           *Endpoint[request.GetQuote, response.Quote, response.Credits, error]
-	getPrice           *Endpoint[request.GetPrice, response.Price, response.Credits, error]
-	getEOD             *Endpoint[request.GetEOD, response.EOD, response.Credits, error]
-	getMarketMovers    *Endpoint[request.GetMarketMovers, response.MarketMovers, response.Credits, error]
-
 	// Fundamentals
 	getLogo                        *Endpoint[request.GetLogo, response.Logo, response.Credits, error]
 	getProfile                     *Endpoint[request.GetProfile, response.Profile, response.Credits, error]
@@ -51,6 +51,7 @@ type client struct {
 	getStatistics                  *Endpoint[request.GetStatistics, response.Statistics, response.Credits, error]
 	getEarningsCalendar            *Endpoint[request.GetEarningsCalendar, response.EarningsCalendar, response.Credits, error]
 	getIPOCalendar                 *Endpoint[request.GetIPOCalendar, response.IPOCalendar, response.Credits, error]
+	getPressReleases               *Endpoint[request.GetPressReleases, response.PressReleases, response.Credits, error]
 	getIncomeStatement             *Endpoint[request.GetIncomeStatement, response.IncomeStatements, response.Credits, error]
 	getIncomeStatementConsolidated *Endpoint[request.GetIncomeStatement, response.IncomeStatements, response.Credits, error]
 	getBalanceSheet                *Endpoint[request.GetBalanceSheet, response.BalanceSheets, response.Credits, error]
@@ -59,6 +60,33 @@ type client struct {
 	getCashFlowConsolidated        *Endpoint[request.GetCashFlow, response.CashFlows, response.Credits, error]
 	getMarketCap                   *Endpoint[request.GetMarketCap, response.MarketCap, response.Credits, error]
 	getLastChange                  *Endpoint[request.GetLastChange, response.LastChange, response.Credits, error]
+
+	// Currencies
+	getExchangeRate       *Endpoint[request.GetExchangeRate, response.ExchangeRate, response.Credits, error]
+	getCurrencyConversion *Endpoint[request.GetCurrencyConversion, response.CurrencyConversion, response.Credits, error]
+
+	// ETFs
+	getETFsDirectory  *Endpoint[request.GetETFsDirectory, response.ETFsDirectory, response.Credits, error]
+	getETFFullData    *Endpoint[request.GetETFFullData, response.ETFFullData, response.Credits, error]
+	getETFSummary     *Endpoint[request.GetETFSummary, response.ETFWorldSummary, response.Credits, error]
+	getETFPerformance *Endpoint[request.GetETFPerformance, response.ETFPerformance, response.Credits, error]
+	getETFRisk        *Endpoint[request.GetETFRisk, response.ETFRisk, response.Credits, error]
+	getETFComposition *Endpoint[request.GetETFComposition, response.ETFComposition, response.Credits, error]
+	getETFFamilies    *Endpoint[request.GetETFFamilies, response.ETFFamilies, response.Credits, error]
+	getETFTypes       *Endpoint[request.GetETFTypes, response.ETFTypes, response.Credits, error]
+
+	// Mutual Funds
+	getMutualFundsDirectory     *Endpoint[request.GetMutualFundsDirectory, response.MutualFundsDirectory, response.Credits, error]
+	getMutualFundFullData       *Endpoint[request.GetMutualFundFullData, response.MutualFundFullData, response.Credits, error]
+	getMutualFundSummary        *Endpoint[request.GetMutualFundSummary, response.MutualFundSummary, response.Credits, error]
+	getMutualFundPerformance    *Endpoint[request.GetMutualFundPerformance, response.MutualFundPerformance, response.Credits, error]
+	getMutualFundRisk           *Endpoint[request.GetMutualFundRisk, response.MutualFundRisk, response.Credits, error]
+	getMutualFundRatings        *Endpoint[request.GetMutualFundRatings, response.MutualFundRatings, response.Credits, error]
+	getMutualFundComposition    *Endpoint[request.GetMutualFundComposition, response.MutualFundComposition, response.Credits, error]
+	getMutualFundPurchaseInfo   *Endpoint[request.GetMutualFundPurchaseInfo, response.MutualFundPurchaseInfo, response.Credits, error]
+	getMutualFundSustainability *Endpoint[request.GetMutualFundSustainability, response.MutualFundSustainability, response.Credits, error]
+	getMutualFundFamilies       *Endpoint[request.GetMutualFundFamilies, response.MutualFundFamilies, response.Credits, error]
+	getMutualFundTypes          *Endpoint[request.GetMutualFundTypes, response.MutualFundTypes, response.Credits, error]
 
 	// Technical Indicators
 	getBBands   *Endpoint[request.GetBBands, response.BBands, response.Credits, error]
@@ -87,37 +115,6 @@ type client struct {
 	getNATR     *Endpoint[request.GetNATR, response.NATR, response.Credits, error]
 	getTR       *Endpoint[request.GetTR, response.TR, response.Credits, error]
 
-	// Currencies
-	getExchangeRate       *Endpoint[request.GetExchangeRate, response.ExchangeRate, response.Credits, error]
-	getCurrencyConversion *Endpoint[request.GetCurrencyConversion, response.CurrencyConversion, response.Credits, error]
-
-	// Advanced
-	getUsage   *Endpoint[request.GetUsage, response.Usage, response.Credits, error]
-	getBatches *Endpoint[request.GetBatches, response.Batches, response.Credits, error]
-
-	// ETFs
-	getETFsDirectory  *Endpoint[request.GetETFsDirectory, response.ETFsDirectory, response.Credits, error]
-	getETFFullData    *Endpoint[request.GetETFFullData, response.ETFFullData, response.Credits, error]
-	getETFSummary     *Endpoint[request.GetETFSummary, response.ETFWorldSummary, response.Credits, error]
-	getETFPerformance *Endpoint[request.GetETFPerformance, response.ETFPerformance, response.Credits, error]
-	getETFRisk        *Endpoint[request.GetETFRisk, response.ETFRisk, response.Credits, error]
-	getETFComposition *Endpoint[request.GetETFComposition, response.ETFComposition, response.Credits, error]
-	getETFFamilies    *Endpoint[request.GetETFFamilies, response.ETFFamilies, response.Credits, error]
-	getETFTypes       *Endpoint[request.GetETFTypes, response.ETFTypes, response.Credits, error]
-
-	// Mutual Funds
-	getMutualFundsDirectory     *Endpoint[request.GetMutualFundsDirectory, response.MutualFundsDirectory, response.Credits, error]
-	getMutualFundFullData       *Endpoint[request.GetMutualFundFullData, response.MutualFundFullData, response.Credits, error]
-	getMutualFundSummary        *Endpoint[request.GetMutualFundSummary, response.MutualFundSummary, response.Credits, error]
-	getMutualFundPerformance    *Endpoint[request.GetMutualFundPerformance, response.MutualFundPerformance, response.Credits, error]
-	getMutualFundRisk           *Endpoint[request.GetMutualFundRisk, response.MutualFundRisk, response.Credits, error]
-	getMutualFundRatings        *Endpoint[request.GetMutualFundRatings, response.MutualFundRatings, response.Credits, error]
-	getMutualFundComposition    *Endpoint[request.GetMutualFundComposition, response.MutualFundComposition, response.Credits, error]
-	getMutualFundPurchaseInfo   *Endpoint[request.GetMutualFundPurchaseInfo, response.MutualFundPurchaseInfo, response.Credits, error]
-	getMutualFundSustainability *Endpoint[request.GetMutualFundSustainability, response.MutualFundSustainability, response.Credits, error]
-	getMutualFundFamilies       *Endpoint[request.GetMutualFundFamilies, response.MutualFundFamilies, response.Credits, error]
-	getMutualFundTypes          *Endpoint[request.GetMutualFundTypes, response.MutualFundTypes, response.Credits, error]
-
 	// Analysis
 	getRecommendations          *Endpoint[request.GetRecommendations, response.Recommendations, response.Credits, error]
 	getPriceTarget              *Endpoint[request.GetPriceTarget, response.PriceTarget, response.Credits, error]
@@ -137,6 +134,10 @@ type client struct {
 	getDirectHolders        *Endpoint[request.GetDirectHolders, response.DirectHolders, response.Credits, error]
 	getTaxInformation       *Endpoint[request.GetTaxInformation, response.TaxInformation, response.Credits, error]
 	getSanctionedEntities   *Endpoint[request.GetSanctionedEntities, response.SanctionedEntities, response.Credits, error]
+
+	// Advanced
+	getUsage   *Endpoint[request.GetUsage, response.Usage, response.Credits, error]
+	getBatches *Endpoint[request.GetBatches, response.Batches, response.Credits, error]
 }
 
 func (cli client) GetStocks(req request.GetStock) (response.Stocks, response.Credits, error) {
@@ -213,6 +214,10 @@ func (cli client) GetSplitsCalendar(req request.GetSplitsCalendar) (response.Spl
 
 func (cli client) GetStatistics(statistics request.GetStatistics) (response.Statistics, response.Credits, error) {
 	return cli.getStatistics.Call(statistics)
+}
+
+func (cli client) GetPressReleases(req request.GetPressReleases) (response.PressReleases, response.Credits, error) {
+	return cli.getPressReleases.Call(req)
 }
 
 func (cli client) GetExchanges(req request.GetExchanges) (response.Exchanges, response.Credits, error) {
@@ -538,6 +543,14 @@ func (cli client) GetAnalystRatingsUSEquities(req request.GetAnalystRatingsUSEqu
 // while cfg contains the API endpoints, authentication, and other client configuration.
 func NewClient(httpCli *HTTPCli, cfg *Conf) Client {
 	return client{
+		// Market Data
+		getTimeSeries:      NewEndpoint[request.GetTimeSeries, response.TimeSeries, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.TimeSeriesURL),
+		getTimeSeriesCross: NewEndpoint[request.GetTimeSeriesCross, response.TimeSeriesCross, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.TimeSeriesCrossURL),
+		getQuote:           NewEndpoint[request.GetQuote, response.Quote, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.QuotesURL),
+		getPrice:           NewEndpoint[request.GetPrice, response.Price, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.PriceURL),
+		getEOD:             NewEndpoint[request.GetEOD, response.EOD, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.EODURL),
+		getMarketMovers:    NewEndpoint[request.GetMarketMovers, response.MarketMovers, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.MarketMoversURL),
+
 		// Reference Data - Asset Catalogs
 		getStocks:           NewEndpoint[request.GetStock, response.Stocks, response.Credits, error](httpCli, cfg.BaseURL+cfg.ReferenceData.StocksURL),
 		getForexPairs:       NewEndpoint[request.GetForexPairs, response.ForexPairs, response.Credits, error](httpCli, cfg.BaseURL+cfg.ReferenceData.ForexPairsURL),
@@ -563,14 +576,6 @@ func NewClient(httpCli *HTTPCli, cfg *Conf) Client {
 		getInstrumentType:      NewEndpoint[request.GetInstrumentType, response.InstrumentType, response.Credits, error](httpCli, cfg.BaseURL+cfg.ReferenceData.InstrumentTypeURL),
 		getTechnicalIndicators: NewEndpoint[request.GetTechnicalIndicators, response.TechnicalIndicators, response.Credits, error](httpCli, cfg.BaseURL+cfg.ReferenceData.TechnicalIndicatorsURL),
 
-		// Core Data
-		getTimeSeries:      NewEndpoint[request.GetTimeSeries, response.TimeSeries, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.TimeSeriesURL),
-		getTimeSeriesCross: NewEndpoint[request.GetTimeSeriesCross, response.TimeSeriesCross, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.TimeSeriesCrossURL),
-		getQuote:           NewEndpoint[request.GetQuote, response.Quote, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.QuotesURL),
-		getPrice:           NewEndpoint[request.GetPrice, response.Price, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.PriceURL),
-		getEOD:             NewEndpoint[request.GetEOD, response.EOD, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.EODURL),
-		getMarketMovers:    NewEndpoint[request.GetMarketMovers, response.MarketMovers, response.Credits, error](httpCli, cfg.BaseURL+cfg.CoreData.MarketMoversURL),
-
 		// Fundamentals
 		getLogo:                        NewEndpoint[request.GetLogo, response.Logo, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.LogoURL),
 		getProfile:                     NewEndpoint[request.GetProfile, response.Profile, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.ProfileURL),
@@ -583,6 +588,7 @@ func NewClient(httpCli *HTTPCli, cfg *Conf) Client {
 		getStatistics:                  NewEndpoint[request.GetStatistics, response.Statistics, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.StatisticsURL),
 		getEarningsCalendar:            NewEndpoint[request.GetEarningsCalendar, response.EarningsCalendar, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.EarningsCalendarURL),
 		getIPOCalendar:                 NewEndpoint[request.GetIPOCalendar, response.IPOCalendar, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.IPOCalendarURL),
+		getPressReleases:               NewEndpoint[request.GetPressReleases, response.PressReleases, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.PressReleasesURL),
 		getIncomeStatement:             NewEndpoint[request.GetIncomeStatement, response.IncomeStatements, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.IncomeStatementURL),
 		getIncomeStatementConsolidated: NewEndpoint[request.GetIncomeStatement, response.IncomeStatements, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.IncomeStatementConsolidatedURL),
 		getBalanceSheet:                NewEndpoint[request.GetBalanceSheet, response.BalanceSheets, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.BalanceSheetURL),
@@ -591,6 +597,33 @@ func NewClient(httpCli *HTTPCli, cfg *Conf) Client {
 		getCashFlowConsolidated:        NewEndpoint[request.GetCashFlow, response.CashFlows, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.CashFlowConsolidatedURL),
 		getMarketCap:                   NewEndpoint[request.GetMarketCap, response.MarketCap, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.MarketCapURL),
 		getLastChange:                  NewEndpoint[request.GetLastChange, response.LastChange, response.Credits, error](httpCli, cfg.BaseURL+cfg.Fundamentals.LastChangeURL),
+
+		// Currencies
+		getExchangeRate:       NewEndpoint[request.GetExchangeRate, response.ExchangeRate, response.Credits, error](httpCli, cfg.BaseURL+cfg.Currencies.ExchangeRateURL),
+		getCurrencyConversion: NewEndpoint[request.GetCurrencyConversion, response.CurrencyConversion, response.Credits, error](httpCli, cfg.BaseURL+cfg.Currencies.CurrencyConversionURL),
+
+		// ETFs
+		getETFsDirectory:  NewEndpoint[request.GetETFsDirectory, response.ETFsDirectory, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsDirectoryURL),
+		getETFFullData:    NewEndpoint[request.GetETFFullData, response.ETFFullData, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsFullDataURL),
+		getETFSummary:     NewEndpoint[request.GetETFSummary, response.ETFWorldSummary, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsSummaryURL),
+		getETFPerformance: NewEndpoint[request.GetETFPerformance, response.ETFPerformance, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsPerformanceURL),
+		getETFRisk:        NewEndpoint[request.GetETFRisk, response.ETFRisk, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsRiskURL),
+		getETFComposition: NewEndpoint[request.GetETFComposition, response.ETFComposition, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsCompositionURL),
+		getETFFamilies:    NewEndpoint[request.GetETFFamilies, response.ETFFamilies, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsFamiliesURL),
+		getETFTypes:       NewEndpoint[request.GetETFTypes, response.ETFTypes, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsTypesURL),
+
+		// Mutual Funds
+		getMutualFundsDirectory:     NewEndpoint[request.GetMutualFundsDirectory, response.MutualFundsDirectory, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsDirectoryURL),
+		getMutualFundFullData:       NewEndpoint[request.GetMutualFundFullData, response.MutualFundFullData, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsFullDataURL),
+		getMutualFundSummary:        NewEndpoint[request.GetMutualFundSummary, response.MutualFundSummary, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsSummaryURL),
+		getMutualFundPerformance:    NewEndpoint[request.GetMutualFundPerformance, response.MutualFundPerformance, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsPerformanceURL),
+		getMutualFundRisk:           NewEndpoint[request.GetMutualFundRisk, response.MutualFundRisk, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsRiskURL),
+		getMutualFundRatings:        NewEndpoint[request.GetMutualFundRatings, response.MutualFundRatings, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsRatingsURL),
+		getMutualFundComposition:    NewEndpoint[request.GetMutualFundComposition, response.MutualFundComposition, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsCompositionURL),
+		getMutualFundPurchaseInfo:   NewEndpoint[request.GetMutualFundPurchaseInfo, response.MutualFundPurchaseInfo, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsPurchaseInfoURL),
+		getMutualFundSustainability: NewEndpoint[request.GetMutualFundSustainability, response.MutualFundSustainability, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsSustainabilityURL),
+		getMutualFundFamilies:       NewEndpoint[request.GetMutualFundFamilies, response.MutualFundFamilies, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsFamiliesURL),
+		getMutualFundTypes:          NewEndpoint[request.GetMutualFundTypes, response.MutualFundTypes, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsTypesURL),
 
 		// Technical Indicators
 		getBBands:   NewEndpoint[request.GetBBands, response.BBands, response.Credits, error](httpCli, cfg.BaseURL+cfg.TechnicalIndicators.BbandsURL),
@@ -619,37 +652,6 @@ func NewClient(httpCli *HTTPCli, cfg *Conf) Client {
 		getNATR:     NewEndpoint[request.GetNATR, response.NATR, response.Credits, error](httpCli, cfg.BaseURL+cfg.TechnicalIndicators.NATRURL),
 		getTR:       NewEndpoint[request.GetTR, response.TR, response.Credits, error](httpCli, cfg.BaseURL+cfg.TechnicalIndicators.TRURL),
 
-		// Currencies
-		getExchangeRate:       NewEndpoint[request.GetExchangeRate, response.ExchangeRate, response.Credits, error](httpCli, cfg.BaseURL+cfg.Currencies.ExchangeRateURL),
-		getCurrencyConversion: NewEndpoint[request.GetCurrencyConversion, response.CurrencyConversion, response.Credits, error](httpCli, cfg.BaseURL+cfg.Currencies.CurrencyConversionURL),
-
-		// Advanced
-		getUsage:   NewEndpoint[request.GetUsage, response.Usage, response.Credits, error](httpCli, cfg.BaseURL+cfg.Advanced.UsageURL),
-		getBatches: NewEndpoint[request.GetBatches, response.Batches, response.Credits, error](httpCli, cfg.BaseURL+cfg.Advanced.BatchesURL),
-
-		// ETFs
-		getETFsDirectory:  NewEndpoint[request.GetETFsDirectory, response.ETFsDirectory, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsDirectoryURL),
-		getETFFullData:    NewEndpoint[request.GetETFFullData, response.ETFFullData, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsFullDataURL),
-		getETFSummary:     NewEndpoint[request.GetETFSummary, response.ETFWorldSummary, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsSummaryURL),
-		getETFPerformance: NewEndpoint[request.GetETFPerformance, response.ETFPerformance, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsPerformanceURL),
-		getETFRisk:        NewEndpoint[request.GetETFRisk, response.ETFRisk, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsRiskURL),
-		getETFComposition: NewEndpoint[request.GetETFComposition, response.ETFComposition, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsCompositionURL),
-		getETFFamilies:    NewEndpoint[request.GetETFFamilies, response.ETFFamilies, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsFamiliesURL),
-		getETFTypes:       NewEndpoint[request.GetETFTypes, response.ETFTypes, response.Credits, error](httpCli, cfg.BaseURL+cfg.ETFs.ETFsTypesURL),
-
-		// Mutual Funds
-		getMutualFundsDirectory:     NewEndpoint[request.GetMutualFundsDirectory, response.MutualFundsDirectory, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsDirectoryURL),
-		getMutualFundFullData:       NewEndpoint[request.GetMutualFundFullData, response.MutualFundFullData, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsFullDataURL),
-		getMutualFundSummary:        NewEndpoint[request.GetMutualFundSummary, response.MutualFundSummary, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsSummaryURL),
-		getMutualFundPerformance:    NewEndpoint[request.GetMutualFundPerformance, response.MutualFundPerformance, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsPerformanceURL),
-		getMutualFundRisk:           NewEndpoint[request.GetMutualFundRisk, response.MutualFundRisk, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsRiskURL),
-		getMutualFundRatings:        NewEndpoint[request.GetMutualFundRatings, response.MutualFundRatings, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsRatingsURL),
-		getMutualFundComposition:    NewEndpoint[request.GetMutualFundComposition, response.MutualFundComposition, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsCompositionURL),
-		getMutualFundPurchaseInfo:   NewEndpoint[request.GetMutualFundPurchaseInfo, response.MutualFundPurchaseInfo, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsPurchaseInfoURL),
-		getMutualFundSustainability: NewEndpoint[request.GetMutualFundSustainability, response.MutualFundSustainability, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsSustainabilityURL),
-		getMutualFundFamilies:       NewEndpoint[request.GetMutualFundFamilies, response.MutualFundFamilies, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsFamiliesURL),
-		getMutualFundTypes:          NewEndpoint[request.GetMutualFundTypes, response.MutualFundTypes, response.Credits, error](httpCli, cfg.BaseURL+cfg.MutualFunds.MutualFundsTypesURL),
-
 		// Analysis
 		getRecommendations:          NewEndpoint[request.GetRecommendations, response.Recommendations, response.Credits, error](httpCli, cfg.BaseURL+cfg.Analysis.RecommendationsURL),
 		getPriceTarget:              NewEndpoint[request.GetPriceTarget, response.PriceTarget, response.Credits, error](httpCli, cfg.BaseURL+cfg.Analysis.PriceTargetURL),
@@ -669,5 +671,9 @@ func NewClient(httpCli *HTTPCli, cfg *Conf) Client {
 		getDirectHolders:        NewEndpoint[request.GetDirectHolders, response.DirectHolders, response.Credits, error](httpCli, cfg.BaseURL+cfg.Regulatory.DirectHoldersURL),
 		getTaxInformation:       NewEndpoint[request.GetTaxInformation, response.TaxInformation, response.Credits, error](httpCli, cfg.BaseURL+cfg.Regulatory.TaxInformationURL),
 		getSanctionedEntities:   NewEndpoint[request.GetSanctionedEntities, response.SanctionedEntities, response.Credits, error](httpCli, cfg.BaseURL+cfg.Regulatory.SanctionedEntitiesURL),
+
+		// Advanced
+		getUsage:   NewEndpoint[request.GetUsage, response.Usage, response.Credits, error](httpCli, cfg.BaseURL+cfg.Advanced.UsageURL),
+		getBatches: NewEndpoint[request.GetBatches, response.Batches, response.Credits, error](httpCli, cfg.BaseURL+cfg.Advanced.BatchesURL),
 	}
 }

--- a/request/press_releases.go
+++ b/request/press_releases.go
@@ -1,0 +1,18 @@
+package request
+
+// GetPressReleases represents request parameters for press releases data.
+// One of Symbol, Figi, Isin, or Cusip is required by the API.
+type GetPressReleases struct {
+	APIKey
+	Symbol     string `schema:"symbol,omitempty"`
+	Figi       string `schema:"figi,omitempty"`
+	Isin       string `schema:"isin,omitempty"`
+	Cusip      string `schema:"cusip,omitempty"`
+	Exchange   string `schema:"exchange,omitempty"`
+	MicCode    string `schema:"mic_code,omitempty"`
+	StartDate  string `schema:"start_date,omitempty"`
+	EndDate    string `schema:"end_date,omitempty"`
+	Language   string `schema:"language,omitempty"`
+	TimeZone   string `schema:"timezone,omitempty"`
+	OutputSize int    `schema:"outputsize,omitempty"`
+}

--- a/response/press_releases.go
+++ b/response/press_releases.go
@@ -1,0 +1,17 @@
+package response
+
+// PressReleases represents the response structure for press releases data.
+type PressReleases struct {
+	PressReleases []PressRelease `json:"press_releases"`
+	Status        string         `json:"status"`
+}
+
+// PressRelease represents a single press release item.
+type PressRelease struct {
+	ID       string   `json:"id"`
+	Datetime string   `json:"datetime"`
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
+	Style    string   `json:"style"`
+	Language []string `json:"language"`
+}


### PR DESCRIPTION
## Summary
- align the documented API coverage and internal section ordering with the current Twelve Data docs structure
- add support for the `press_releases` fundamentals endpoint, including request/response models, client wiring, config, credits, and tests
- clean up the README grouping so regulatory and WebSocket sections match the current docs layout

## Testing
- `make test`
- `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Market Data endpoints for time series, quotes, prices, EOD data, and market movers
  * Added fundamentals data: press releases, earnings calendar, and IPO calendar
  * Added 23 technical indicators for market analysis
  * Added advanced features: usage analytics and batch operations
  * Added WebSocket support for real-time price updates

* **Documentation**
  * Standardized API documentation with updated terminology and improved organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->