### PR TITLE
Prepare v1.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v7
         with:
           go-version: 1.26.x
@@ -37,6 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,13 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: lint (Go 1.26.x)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version-file: go.mod
+          go-version: 1.26.x
           cache: true
 
       - name: golangci-lint
@@ -26,7 +26,14 @@ jobs:
           version: v2.9.0
 
   tests:
+    name: tests (Go ${{ matrix.go-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.25.x
+          - 1.26.x
 
     steps:
       - uses: actions/checkout@v7
@@ -34,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go-version }}
           cache: true
 
       - name: Test

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 go get github.com/soulgarden/twelvedata@latest
 ```
 
+Requires Go 1.25 or newer. CI validates the latest patch releases of Go 1.25 and Go 1.26.
+
 If you're upgrading from `v0.1.x`, see `MIGRATION.md`.
 
 # Covered:

--- a/docs/superpowers/plans/2026-07-18-v1.1.0-release.md
+++ b/docs/superpowers/plans/2026-07-18-v1.1.0-release.md
@@ -1,0 +1,301 @@
+# v1.1.0 Security and Go Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `v1.1.0` with the `golang.org/x/net` security update, a documented Go 1.25 minimum, and CI coverage for supported Go release lines.
+
+**Architecture:** Merge the narrow Dependabot security PR first with an expected-head guard. Build the remaining release changes on `release/v1.1.0`, validate them on the latest Go 1.25 and 1.26 patch toolchains, merge through a reviewed PR, publish the tag, and only then rebase the broader dependency PR #38.
+
+**Tech Stack:** Go modules, GitHub Actions, Dependabot, GitHub CLI, govulncheck, golangci-lint.
+
+## Global Constraints
+
+- Merge Dependabot PR #39 only while its head is `f6a24581509d2d6fdc2c574f5a09048e8e370a21`.
+- Set the module minimum to Go `1.25.0` through PR #39.
+- Test the latest patch releases of Go `1.25.x` and `1.26.x`; do not pin CI to `1.25.0`.
+- Keep PR #38 out of `v1.1.0`; rebase and reassess it after the release.
+- Use SemVer tag `v1.1.0` and document the minimum Go version in the release notes.
+
+---
+
+### Task 1: Merge the narrow security update
+
+**Files:**
+- Modify through PR #39: `go.mod`
+- Modify through PR #39: `go.sum`
+
+**Interfaces:**
+- Consumes: PR #39 head `f6a24581509d2d6fdc2c574f5a09048e8e370a21` with green `tests` and `lint` jobs.
+- Produces: `main` requiring `golang.org/x/net v0.55.0`, `golang.org/x/sys v0.45.0`, and Go `1.25.0`.
+
+- [ ] **Step 1: Recheck the immutable PR inputs**
+
+Run:
+
+```bash
+gh pr view 39 --repo soulgarden/twelvedata --json state,mergeable,mergeStateStatus,headRefOid,files,statusCheckRollup
+```
+
+Expected: `OPEN`, `MERGEABLE`, `CLEAN`, exact head SHA, only `go.mod` and `go.sum`, and successful `tests` and `lint`.
+
+- [ ] **Step 2: Squash-merge with a head guard**
+
+Run:
+
+```bash
+gh pr merge 39 --repo soulgarden/twelvedata --squash --match-head-commit f6a24581509d2d6fdc2c574f5a09048e8e370a21
+```
+
+Expected: exit code 0 and PR state `MERGED`.
+
+- [ ] **Step 3: Verify the merge and post-merge Actions run**
+
+Run `gh pr view 39 --repo soulgarden/twelvedata --json state,mergedAt,mergeCommit`, then inspect the `Tests and linters` run for the merge commit with `gh run list` and `gh run view`.
+
+Expected: merged state and successful `tests` and `lint` jobs.
+
+### Task 2: Synchronize the release branch
+
+**Files:**
+- No content changes.
+
+**Interfaces:**
+- Consumes: merged `origin/main` from Task 1.
+- Produces: local `release/v1.1.0` at the same commit as `origin/main` before release-specific edits.
+
+- [ ] **Step 1: Fast-forward local main**
+
+Run:
+
+```bash
+git switch main
+git fetch origin main
+git merge --ff-only origin/main
+```
+
+Expected: local `main` equals `origin/main`.
+
+- [ ] **Step 2: Fast-forward the release branch**
+
+Run:
+
+```bash
+git switch release/v1.1.0
+git merge --ff-only main
+```
+
+Expected: clean `release/v1.1.0` at the merged PR #39 commit.
+
+### Task 3: Define supported Go versions in CI and documentation
+
+**Files:**
+- Modify: `.github/workflows/main.yml`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `go 1.25.0` from Task 1.
+- Produces: tests on `1.25.x` and `1.26.x`, lint on `1.26.x`, and a public minimum-Go statement.
+
+- [ ] **Step 1: Update the workflow**
+
+Set the relevant jobs to:
+
+```yaml
+  golangci:
+    name: lint (Go 1.26.x)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: 1.26.x
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.9.0
+
+  tests:
+    name: tests (Go ${{ matrix.go-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.25.x
+          - 1.26.x
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Test
+        run: ROOT_DIR=${PWD} go test -v -failfast ./...
+```
+
+- [ ] **Step 2: Document the support floor**
+
+Add after the installation command in `README.md`:
+
+```markdown
+Requires Go 1.25 or newer. CI validates the latest patch releases of Go 1.25 and Go 1.26.
+```
+
+- [ ] **Step 3: Validate YAML syntax and inspect the diff**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/main.yml")'
+git diff --check
+git diff -- .github/workflows/main.yml README.md
+```
+
+Expected: successful YAML parse, no whitespace errors, and only the intended CI/documentation changes.
+
+### Task 4: Validate the release candidate locally
+
+**Files:**
+- Verify: `go.mod`
+- Verify: `go.sum`
+- Verify: all Go packages.
+
+**Interfaces:**
+- Consumes: release candidate from Tasks 1-3.
+- Produces: reproducible test, lint, tidy, and vulnerability evidence.
+
+- [ ] **Step 1: Verify module tidiness with the minimum supported release line**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.12 go mod tidy -diff
+```
+
+Expected: exit code 0 and no diff.
+
+- [ ] **Step 2: Test both supported release lines**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.12 go test ./...
+GOTOOLCHAIN=go1.26.5 go test ./...
+```
+
+Expected: all packages pass on both toolchains.
+
+- [ ] **Step 3: Run the pinned linter and vulnerability scanner**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.26.5 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run
+GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+```
+
+Expected: lint succeeds and govulncheck reports no reachable vulnerabilities.
+
+### Task 5: Publish and merge the release PR
+
+**Files:**
+- Commit: `.github/workflows/main.yml`
+- Commit: `README.md`
+- Commit: `docs/superpowers/plans/2026-07-18-v1.1.0-release.md`
+
+**Interfaces:**
+- Consumes: fully validated local release branch.
+- Produces: reviewed and merged PR from `release/v1.1.0` to `main`.
+
+- [ ] **Step 1: Commit the release policy changes**
+
+Run:
+
+```bash
+git add .github/workflows/main.yml README.md docs/superpowers/plans/2026-07-18-v1.1.0-release.md
+git commit -m "Prepare Go 1.25 support for v1.1.0"
+```
+
+Expected: one focused commit after the merged security commit.
+
+- [ ] **Step 2: Push and create the PR**
+
+Run:
+
+```bash
+git push -u origin release/v1.1.0
+gh pr create --repo soulgarden/twelvedata --base main --head release/v1.1.0 --title "Prepare v1.1.0" --body-file /tmp/twelvedata-v1.1.0-pr.md
+```
+
+The PR body must state the security dependency versions, minimum Go `1.25`, CI matrix, and local validation commands.
+
+- [ ] **Step 3: Wait for exact-head checks and squash-merge**
+
+Run `gh pr checks` until all required checks pass, then merge with `gh pr merge --squash --match-head-commit <verified-head-sha>`.
+
+Expected: PR merged without head drift.
+
+### Task 6: Publish and verify v1.1.0
+
+**Files:**
+- No additional repository content changes.
+
+**Interfaces:**
+- Consumes: green release merge commit on `main`.
+- Produces: public GitHub release and Go module tag `v1.1.0`.
+
+- [ ] **Step 1: Synchronize and verify main**
+
+Fetch `origin/main`, fast-forward local `main`, run `go test ./...` with Go `1.25.12` and `1.26.5`, and confirm the post-merge GitHub Actions jobs are successful.
+
+- [ ] **Step 2: Create the release**
+
+Run:
+
+```bash
+gh release create v1.1.0 --repo soulgarden/twelvedata --target main --title v1.1.0 --generate-notes
+```
+
+Expected: published, non-prerelease release pointing at the verified merge commit.
+
+- [ ] **Step 3: Verify the public module version**
+
+Run:
+
+```bash
+gh release view v1.1.0 --repo soulgarden/twelvedata --json tagName,isDraft,isPrerelease,targetCommitish,url
+GOTOOLCHAIN=go1.26.5 go list -m github.com/soulgarden/twelvedata@v1.1.0
+```
+
+Expected: tag `v1.1.0`, published release, and successful module resolution.
+
+### Task 7: Rebase and reassess PR #38
+
+**Files:**
+- No local content changes unless a follow-up is approved.
+
+**Interfaces:**
+- Consumes: released `v1.1.0` with `x/net v0.55.0` and `x/sys v0.45.0`.
+- Produces: refreshed evidence for the remaining grouped dependency update.
+
+- [ ] **Step 1: Ask Dependabot to rebase**
+
+Run:
+
+```bash
+gh pr comment 38 --repo soulgarden/twelvedata --body '@dependabot rebase'
+```
+
+- [ ] **Step 2: Wait for a new head and CI**
+
+Confirm that PR #38 has a new base/head relationship, inspect its exact patch, and wait for `tests` and `lint` to complete.
+
+- [ ] **Step 3: Stop before merging #38**
+
+Report the refreshed dependency set and risk assessment. Do not merge #38 as part of `v1.1.0`.

--- a/docs/superpowers/plans/2026-07-18-v1.1.0-release.md
+++ b/docs/superpowers/plans/2026-07-18-v1.1.0-release.md
@@ -106,6 +106,8 @@ Set the relevant jobs to:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v7
         with:
           go-version: 1.26.x
@@ -128,6 +130,8 @@ Set the relevant jobs to:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -185,8 +189,8 @@ Expected: exit code 0 and no diff.
 Run:
 
 ```bash
-GOTOOLCHAIN=go1.25.12 go test ./...
-GOTOOLCHAIN=go1.26.5 go test ./...
+ROOT_DIR=${PWD} GOTOOLCHAIN=go1.25.12 go test ./...
+ROOT_DIR=${PWD} GOTOOLCHAIN=go1.26.5 go test ./...
 ```
 
 Expected: all packages pass on both toolchains.
@@ -226,6 +230,28 @@ Expected: one focused commit after the merged security commit.
 
 - [ ] **Step 2: Push and create the PR**
 
+Create `/tmp/twelvedata-v1.1.0-pr.md` with this exact body:
+
+```markdown
+## Summary
+
+- document Go 1.25 as the minimum supported version
+- test the latest Go 1.25 and Go 1.26 patch releases in CI
+- run golangci-lint on the latest Go 1.26 patch release
+- record the guarded v1.1.0 release procedure
+
+This follows the separately merged security update in #39 (`golang.org/x/net v0.55.0`, `golang.org/x/sys v0.45.0`). PR #38 remains outside this release and will be rebased afterward.
+
+## Validation
+
+- `GOTOOLCHAIN=go1.25.12 go mod tidy -diff`
+- `ROOT_DIR=${PWD} GOTOOLCHAIN=go1.25.12 go test ./...`
+- `ROOT_DIR=${PWD} GOTOOLCHAIN=go1.26.5 go test ./...`
+- `GOTOOLCHAIN=go1.26.5 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
+- `GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
+- YAML parse and `git diff --check`
+```
+
 Run:
 
 ```bash
@@ -252,7 +278,7 @@ Expected: PR merged without head drift.
 
 - [ ] **Step 1: Synchronize and verify main**
 
-Fetch `origin/main`, fast-forward local `main`, run `go test ./...` with Go `1.25.12` and `1.26.5`, and confirm the post-merge GitHub Actions jobs are successful.
+Fetch `origin/main`, fast-forward local `main`, run `ROOT_DIR=${PWD} go test ./...` with Go `1.25.12` and `1.26.5`, and confirm the post-merge GitHub Actions jobs are successful.
 
 - [ ] **Step 2: Create the release**
 


### PR DESCRIPTION
## Summary

- document Go 1.25 as the minimum supported version
- test the latest Go 1.25 and Go 1.26 patch releases in CI
- run golangci-lint on the latest Go 1.26 patch release
- record the guarded v1.1.0 release procedure

This follows the separately merged security update in #39 (`golang.org/x/net v0.55.0`, `golang.org/x/sys v0.45.0`). PR #38 remains outside this release and will be rebased afterward.

## Validation

- `GOTOOLCHAIN=go1.25.12 go mod tidy -diff`
- `GOTOOLCHAIN=go1.25.12 go test ./...`
- `GOTOOLCHAIN=go1.26.5 go test ./...`
- `GOTOOLCHAIN=go1.26.5 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- `GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- YAML parse and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to require Go 1.25 or newer.
  * Added release planning documentation for version 1.1.0.

* **Chores**
  * Expanded automated validation across Go 1.25 and Go 1.26.
  * Updated linting to use Go 1.26.
  * CI now checks the latest patch releases for supported Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->